### PR TITLE
Implement multi-agency support

### DIFF
--- a/src/main/java/alta/imobiliaria/config/AgencyFilter.java
+++ b/src/main/java/alta/imobiliaria/config/AgencyFilter.java
@@ -1,0 +1,44 @@
+package alta.imobiliaria.config;
+
+import alta.imobiliaria.domain.Agency;
+import alta.imobiliaria.repository.AgencyRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.persistence.EntityManager;
+import org.hibernate.Session;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class AgencyFilter extends OncePerRequestFilter {
+    private final EntityManager entityManager;
+    private final AgencyRepository agencyRepository;
+
+    public AgencyFilter(EntityManager entityManager, AgencyRepository agencyRepository) {
+        this.entityManager = entityManager;
+        this.agencyRepository = agencyRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        Session session = entityManager.unwrap(Session.class);
+        try {
+            String domain = request.getHeader("X-Agency-Domain");
+            if (domain == null || domain.isBlank()) {
+                domain = request.getServerName();
+            }
+            Agency agency = agencyRepository.findByDomain(domain).orElse(null);
+            if (agency != null) {
+                session.enableFilter("agencyFilter").setParameter("agencyId", agency.getId());
+            }
+            filterChain.doFilter(request, response);
+        } finally {
+            session.disableFilter("agencyFilter");
+        }
+    }
+}

--- a/src/main/java/alta/imobiliaria/domain/Agency.java
+++ b/src/main/java/alta/imobiliaria/domain/Agency.java
@@ -1,0 +1,19 @@
+package alta.imobiliaria.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "agencies")
+public class Agency {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String domain;
+}

--- a/src/main/java/alta/imobiliaria/domain/Property.java
+++ b/src/main/java/alta/imobiliaria/domain/Property.java
@@ -1,15 +1,20 @@
 package alta.imobiliaria.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Data;
 
 import java.math.BigDecimal;
 
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+import alta.imobiliaria.domain.Agency;
+
 @Data
 @Entity
+@FilterDef(name = "agencyFilter", parameters = @ParamDef(name = "agencyId", type = Long.class))
+@Filter(name = "agencyFilter", condition = "agency_id = :agencyId")
 public class Property {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -19,4 +24,8 @@ public class Property {
     private String description;
     private BigDecimal price;
     private String address;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agency_id", nullable = false)
+    private Agency agency;
 }

--- a/src/main/java/alta/imobiliaria/domain/User.java
+++ b/src/main/java/alta/imobiliaria/domain/User.java
@@ -3,9 +3,17 @@ package alta.imobiliaria.domain;
 import jakarta.persistence.*;
 import lombok.Data;
 
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+import alta.imobiliaria.domain.Agency;
+
 @Data
 @Entity
 @Table(name = "users")
+@FilterDef(name = "agencyFilter", parameters = @ParamDef(name = "agencyId", type = Long.class))
+@Filter(name = "agencyFilter", condition = "agency_id = :agencyId")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -16,4 +24,8 @@ public class User {
 
     @Column(nullable = false)
     private String password;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agency_id", nullable = false)
+    private Agency agency;
 }

--- a/src/main/java/alta/imobiliaria/repository/AgencyRepository.java
+++ b/src/main/java/alta/imobiliaria/repository/AgencyRepository.java
@@ -1,0 +1,12 @@
+package alta.imobiliaria.repository;
+
+import alta.imobiliaria.domain.Agency;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AgencyRepository extends JpaRepository<Agency, Long> {
+    Optional<Agency> findByDomain(String domain);
+}

--- a/src/test/java/alta/imobiliaria/SecurityTests.java
+++ b/src/test/java/alta/imobiliaria/SecurityTests.java
@@ -1,7 +1,9 @@
 package alta.imobiliaria;
 
 import alta.imobiliaria.domain.User;
+import alta.imobiliaria.domain.Agency;
 import alta.imobiliaria.repository.UserRepository;
+import alta.imobiliaria.repository.AgencyRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,14 +27,25 @@ class SecurityTests {
     private UserRepository repository;
 
     @Autowired
+    private AgencyRepository agencyRepository;
+
+    @Autowired
     private PasswordEncoder encoder;
 
     @BeforeEach
     void setUp() {
         repository.deleteAll();
+        agencyRepository.deleteAll();
+
+        Agency agency = new Agency();
+        agency.setName("Default");
+        agency.setDomain("localhost");
+        agency = agencyRepository.save(agency);
+
         User user = new User();
         user.setUsername("user");
         user.setPassword(encoder.encode("password"));
+        user.setAgency(agency);
         repository.save(user);
     }
 


### PR DESCRIPTION
## Summary
- add `Agency` entity
- associate `Property` and `User` with an `Agency`
- enforce filtering per agency via `AgencyFilter`
- expose repository for `Agency`
- adjust security tests for new entity relations

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685b0c18fc9c8333b23fec9a0218a2cd