### PR TITLE
Fix duplicate filter definition

### DIFF
--- a/src/main/java/alta/imobiliaria/domain/Agency.java
+++ b/src/main/java/alta/imobiliaria/domain/Agency.java
@@ -2,10 +2,13 @@ package alta.imobiliaria.domain;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 
 @Data
 @Entity
 @Table(name = "agencies")
+@FilterDef(name = "agencyFilter", parameters = @ParamDef(name = "agencyId", type = Long.class))
 public class Agency {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/alta/imobiliaria/domain/Property.java
+++ b/src/main/java/alta/imobiliaria/domain/Property.java
@@ -6,14 +6,11 @@ import lombok.Data;
 import java.math.BigDecimal;
 
 import org.hibernate.annotations.Filter;
-import org.hibernate.annotations.FilterDef;
-import org.hibernate.annotations.ParamDef;
 
 import alta.imobiliaria.domain.Agency;
 
 @Data
 @Entity
-@FilterDef(name = "agencyFilter", parameters = @ParamDef(name = "agencyId", type = Long.class))
 @Filter(name = "agencyFilter", condition = "agency_id = :agencyId")
 public class Property {
     @Id

--- a/src/main/java/alta/imobiliaria/domain/User.java
+++ b/src/main/java/alta/imobiliaria/domain/User.java
@@ -4,15 +4,12 @@ import jakarta.persistence.*;
 import lombok.Data;
 
 import org.hibernate.annotations.Filter;
-import org.hibernate.annotations.FilterDef;
-import org.hibernate.annotations.ParamDef;
 
 import alta.imobiliaria.domain.Agency;
 
 @Data
 @Entity
 @Table(name = "users")
-@FilterDef(name = "agencyFilter", parameters = @ParamDef(name = "agencyId", type = Long.class))
 @Filter(name = "agencyFilter", condition = "agency_id = :agencyId")
 public class User {
     @Id


### PR DESCRIPTION
## Summary
- centralize Hibernate `agencyFilter` definition in `Agency`
- remove duplicate `@FilterDef` from `Property` and `User`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685b2107be6083339a72dfc4ed56c2b8