### PR TITLE
Add open user registration endpoint

### DIFF
--- a/src/main/java/alta/imobiliaria/config/SecurityConfig.java
+++ b/src/main/java/alta/imobiliaria/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -35,7 +36,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/users").permitAll()
+                        .anyRequest().authenticated())
                 .formLogin(Customizer.withDefaults())
                 .httpBasic(Customizer.withDefaults());
         return http.build();

--- a/src/main/java/alta/imobiliaria/controller/UserController.java
+++ b/src/main/java/alta/imobiliaria/controller/UserController.java
@@ -1,0 +1,29 @@
+package alta.imobiliaria.controller;
+
+import alta.imobiliaria.domain.User;
+import alta.imobiliaria.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserRepository repository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserController(UserRepository repository, PasswordEncoder passwordEncoder) {
+        this.repository = repository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @PostMapping
+    public ResponseEntity<User> create(@RequestBody User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        User saved = repository.save(user);
+        return ResponseEntity.created(URI.create("/users/" + saved.getId())).body(saved);
+    }
+}

--- a/src/test/java/alta/imobiliaria/SecurityTests.java
+++ b/src/test/java/alta/imobiliaria/SecurityTests.java
@@ -11,6 +11,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.MediaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -31,6 +33,9 @@ class SecurityTests {
 
     @Autowired
     private PasswordEncoder encoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
@@ -65,5 +70,20 @@ class SecurityTests {
     void invalidCredentialsFail() throws Exception {
         mvc.perform(get("/properties").with(httpBasic("user", "wrong")))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void canCreateUserWithoutAuthentication() throws Exception {
+        Agency agency = agencyRepository.findAll().getFirst();
+        User newUser = new User();
+        newUser.setUsername("newuser");
+        newUser.setPassword("newpass");
+        newUser.setAgency(agency);
+
+        mvc.perform(
+                org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newUser))
+        ).andExpect(status().isCreated());
     }
 }


### PR DESCRIPTION
## Summary
- allow anonymous POST to `/users`
- add `UserController` to create users with encoded password
- test open user registration

## Testing
- `./mvnw -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b27891f588333a3bc356d8b3f4af9